### PR TITLE
Making e2e-olm more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# OLM Test Script
+
+## Description
+This script can be used to test install your operator's manifest file in an OCP cluster
+
+### Variables
+| *DEBUG* | default false | Set this to true to enable debug output of the e2e-olm script |
+
+| *TEST_NAMESPACE* | default olm-test | This is the namespace where the test subscription, operator group, and csv will be installed to. Note: this will not be created by this script. |
+
+| *MANIFEST_DIR* | default ./deploy/manifests | This is the path to your operator's manifest directory. |
+
+| *VERSION* | default 4.1 | The version directory under $MANIFEST_DIR where your operator's csv file exists. |
+
+### Execution
+MANIFEST_DIR=/data/src/github.com/openshift/ansible-service-broker ./e2e-olm.sh
+
+
+### Debugging
+
+#### If the test fails while checking the status of subscriptions/olm-testing
+Remove any previously created objects for this test (if you are using the olm-test namespace you can simply run 'oc delete namespace olm-test && oc create namespace olm-test').
+
+If that does not resolve this, verify that your \*package.yaml file is pointing to the correct csv in your manifest dir.
+
+#### If the test fails while installing your CSV
+Your operator may not have been able to start as part of the installation; check the events of your operator pod and adjust your manifest accordingly.
+oc get pods -n olm-test
+oc describe pod -n olm-test {pod_name}

--- a/operatorgroup.yaml
+++ b/operatorgroup.yaml
@@ -1,4 +1,4 @@
-apiVersion: operators.coreos.com/v1
+apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: openshift-olm-test

--- a/subscription.yaml
+++ b/subscription.yaml
@@ -1,12 +1,32 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
+apiVersion: template.openshift.io/v1
+kind: "Template"
 metadata:
-  name: olm-testing
-  namespace: olm-test
-spec:
-  source: openshift-olm-test
-  sourceNamespace: olm-test
-  #YOU NEED TO ADD THE CSV FILE HERE!
-  name: openshiftansibleservicebroker
-  startingCSV: openshiftansibleservicebroker.v4.1.0
-  channel: stable
+  name: csv-subscription-template
+  annotations:
+    description: "Template for creating subscription for e2e-olm test"
+    tags: "e2e"
+objects:
+- apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: olm-testing
+    namespace: olm-test
+  spec:
+    source: openshift-olm-test
+    sourceNamespace: olm-test
+    name: ${CSV_NAME}
+    startingCSV: ${STARTING_CSV}
+    channel: ${CHANNEL}
+parameters:
+-
+  description: 'name of the CSV to use for the subscription'
+  name: CSV_NAME
+  value: openshiftansibleservicebroker
+-
+  description: 'the starting CSV to use for the subscription'
+  name: STARTING_CSV
+  value: openshiftansibleservicebroker.v4.1.0
+-
+  description:
+  name: CHANNEL
+  value: stable


### PR DESCRIPTION
Designed to be run from this dir and point to operator manifest dirs.
Created a basic README.md file