### PR TITLE
support AllNamespaces operators; some script cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This script can be used to test install your operator's manifest file in an OCP 
 
 | *TEST_NAMESPACE* | default olm-test | This is the namespace where the test subscription, operator group, and csv will be installed to. Note: this will not be created by this script. |
 
+| *TARGET_NAMESPACE* | default olm-test | This is the namespace which contains the CR managed by this operator |
+
 | *MANIFEST_DIR* | default ./deploy/manifests | This is the path to your operator's manifest directory. |
 
 | *VERSION* | default 4.1 | The version directory under $MANIFEST_DIR where your operator's csv file exists. |
@@ -15,6 +17,16 @@ This script can be used to test install your operator's manifest file in an OCP 
 ### Execution
 MANIFEST_DIR=/data/src/github.com/openshift/ansible-service-broker ./e2e-olm.sh
 
+`TARGET_NAMESPACE` - for example, cluster logging uses the `elasticsearch-operator` deployed in the
+`openshift-operators-redhat` namespace, but the actual `elasticsearch` CR is created in the
+`openshift-logging` namespace, as are the actual Elasticsearch pods and other resources managed by
+the `elasticsearch-operator`.  Therefore, when using the script to deploy the `elasticsearch-operator`,
+use `TARGET_NAMESPACE=openshift-logging` so that the operator can manage resources in the `openshift-logging`
+namespace, even though the elasticsearch subscription and operator are in the `openshift-operators-redhat`
+namespace.
+If the operator watches for CRs in all namespaces, that is, if the CSV
+has `spec.installModes` type `AllNamespaces` supported `true`, then specify
+`TARGET_NAMESPACE=all`
 
 ### Debugging
 

--- a/e2e-olm.sh
+++ b/e2e-olm.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
 if [ "${DEBUG:-}" = "true" ]; then
 	set -x
 fi
@@ -22,11 +25,19 @@ indent() {
 
 # TODO: RIPPED from the upstream kube test shell library. Everyone will need
 # this. What do we do? -- Thanks pmorie
-readonly reset=$(tput sgr0)
-readonly  bold=$(tput bold)
-readonly black=$(tput setaf 0)
-readonly   red=$(tput setaf 1)
-readonly green=$(tput setaf 2)
+if [ -t 1 ] ; then
+  readonly reset=$(tput sgr0)
+  readonly  bold=$(tput bold)
+  readonly black=$(tput setaf 0)
+  readonly   red=$(tput setaf 1)
+  readonly green=$(tput setaf 2)
+else
+  readonly reset=""
+  readonly  bold=""
+  readonly black=""
+  readonly   red="ERROR "
+  readonly green="SUCCESS "
+fi
 
 test::object_assert() {
   local tries=$1
@@ -36,7 +47,7 @@ test::object_assert() {
   local args=${5:-}
 
   for j in $(seq 1 ${tries}); do
-    res=$(eval oc get ${args} ${object} -o jsonpath=\"${request}\")
+    res=$(eval oc get ${args} ${object} -o jsonpath=\"${request}\") || :
     echo $res
     if [[ "${res}" =~ ^$expected$ ]]; then
       echo -n "${green}"
@@ -45,7 +56,7 @@ test::object_assert() {
       return 0
     fi
     echo "Waiting for Get ${object} ${request} ${args}: expected: ${expected}, got: ${res}"
-    sleep $((${j}-1))
+    sleep $((${j}-1)) || :
   done
   echo "${bold}${red}"
   echo "FAIL!"
@@ -90,7 +101,11 @@ PACKAGE_NAME=$(sed -nr 's,.*packageName: (.*),\1,p' $MANIFEST_DIR/*package.yaml)
 
 oc create -n $TEST_NAMESPACE -f /tmp/configmap.yaml
 if [ "${CREATE_OPERATORGROUP}" == "true" ] ; then
-  oc process -f "$(dirname $0)/operatorgroup-template.yaml" -p TARGET_NAMESPACE=${NAMESPACE} | oc create -n $TEST_NAMESPACE -f -
+  if [ "${TARGET_NAMESPACE}" = all ] ; then
+    oc process -f "$(dirname $0)/operatorgroup-allnamespaces-template.yaml" | oc create -n $TEST_NAMESPACE -f -
+  else
+    oc process -f "$(dirname $0)/operatorgroup-template.yaml" -p TARGET_NAMESPACE=${TARGET_NAMESPACE} | oc create -n $TEST_NAMESPACE -f -
+  fi
 fi
 
 oc process -f "$(dirname $0)/subscription.yaml" -p SUFFIX=${SUFFIX:-} -p CONFIGMAP_NAME=${CONFIGMAP_NAME:-} -p TEST_NAMESPACE=${NAMESPACE} -p PACKAGE_NAME=${PACKAGE_NAME} -p STARTING_CSV=${CURRENT_CSV} -p CHANNEL=${CSV_CHANNEL} | oc create -n $TEST_NAMESPACE -f -

--- a/operatorgroup-allnamespaces-template.yaml
+++ b/operatorgroup-allnamespaces-template.yaml
@@ -10,10 +10,4 @@ objects:
   kind: OperatorGroup
   metadata:
     name: openshift-olm-test
-  spec:
-    targetNamespaces:
-    - "${TARGET_NAMESPACE}"
-parameters:
-- description:
-  name: TARGET_NAMESPACE
-  value: olm-test
+  spec: {}


### PR DESCRIPTION
There was a bug in the script that it was not using the
TARGET_NAMESPACE.
Some operators watch for CRs in all namespaces - they use
installModes AllNamespaces - when creating the operatorgroup,
we have to use an empty spec `{}` so that it will apply to all
namespaces.

Run the script with `set -euo pipefail` and cleanup some of the
issues found.